### PR TITLE
[25.02.28 / TASK-116,TASK-103] Modify - 캐시 충돌 문제 해결

### DIFF
--- a/src/apis/instance.request.ts
+++ b/src/apis/instance.request.ts
@@ -78,7 +78,6 @@ export const instance = async <I, R>(
     if (location && !context.ok && context.status === 401) {
       window.location.replace('/');
     }
-    //context.status === 401 ||
     setContext('Request', {
       path: context.url,
       status: context.status,

--- a/src/apis/instance.request.ts
+++ b/src/apis/instance.request.ts
@@ -75,7 +75,7 @@ export const instance = async <I, R>(
     return (data.body as unknown as SuccessType<R>).data;
   } catch (err: unknown) {
     const context = err as Response;
-    if (location && !context.ok && context.status === 403) {
+    if (location && !context.ok && context.status === 401) {
       window.location.replace('/');
     }
     //context.status === 401 ||

--- a/src/app/(with-tracker)/(login)/Content.tsx
+++ b/src/app/(with-tracker)/(login)/Content.tsx
@@ -3,24 +3,17 @@
 import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 import Image from 'next/image';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useEffect } from 'react';
+import { useMutation } from '@tanstack/react-query';
 import { Input, Button } from '@/components';
 import { LoginVo } from '@/types';
 import { login, sampleLogin } from '@/apis';
 import { trackUserEvent, MessageEnum } from '@/utils/trackUtil';
-import { PATHS } from '@/constants';
 
 const responsiveStyle =
   "flex items-center gap-5 max-MBI:before:inline-block max-MBI:before:bg-[url('/favicon.png')] max-MBI:before:[background-size:_100%_100%] max-MBI:before:w-16 max-MBI:before:h-16";
 
 export const Content = () => {
   const { replace } = useRouter();
-  const client = useQueryClient();
-
-  useEffect(() => {
-    if (client.getQueryData([PATHS.ME])) client.removeQueries();
-  }, []);
 
   const {
     register,
@@ -29,7 +22,6 @@ export const Content = () => {
   } = useForm<LoginVo>({ mode: 'all' });
 
   const onSuccess = () => {
-    client.clear();
     trackUserEvent(MessageEnum.LOGIN);
     replace('/main?asc=false&sort=');
   };

--- a/src/app/(with-tracker)/(login)/Content.tsx
+++ b/src/app/(with-tracker)/(login)/Content.tsx
@@ -4,10 +4,12 @@ import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 import Image from 'next/image';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
 import { Input, Button } from '@/components';
 import { LoginVo } from '@/types';
 import { login, sampleLogin } from '@/apis';
 import { trackUserEvent, MessageEnum } from '@/utils/trackUtil';
+import { PATHS } from '@/constants';
 
 const responsiveStyle =
   "flex items-center gap-5 max-MBI:before:inline-block max-MBI:before:bg-[url('/favicon.png')] max-MBI:before:[background-size:_100%_100%] max-MBI:before:w-16 max-MBI:before:h-16";
@@ -15,6 +17,10 @@ const responsiveStyle =
 export const Content = () => {
   const { replace } = useRouter();
   const client = useQueryClient();
+
+  useEffect(() => {
+    if (client.getQueryData([PATHS.ME])) client.removeQueries();
+  }, []);
 
   const {
     register,

--- a/src/components/auth-required/header/index.tsx
+++ b/src/components/auth-required/header/index.tsx
@@ -3,12 +3,13 @@
 import { useEffect, useRef, useState } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import Image from 'next/image';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { PATHS, SCREENS } from '@/constants';
 import { NameType } from '@/components';
 import { useResponsive } from '@/hooks';
 import { logout, me } from '@/apis';
 import { trackUserEvent, MessageEnum } from '@/utils/trackUtil';
+import { revalidate } from '@/utils/revalidateUtil';
 import { defaultStyle, Section, textStyle } from './Section';
 
 const PARAMS = {
@@ -33,18 +34,13 @@ export const Header = () => {
   const router = useRouter();
   const width = useResponsive();
   const barWidth = width < SCREENS.MBI ? 65 : 180;
-  const client = useQueryClient();
 
   const { mutate: out } = useMutation({
     mutationFn: logout,
-    onMutate: () => router.replace('/'),
-    onSuccess: () => client.removeQueries(),
+    onSuccess: revalidate,
   });
 
-  const { data: profiles } = useQuery({
-    queryKey: [PATHS.ME],
-    queryFn: me,
-  });
+  const { data: profiles } = useQuery({ queryKey: [PATHS.ME], queryFn: me });
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) =>

--- a/src/components/auth-required/main/Section/index.tsx
+++ b/src/components/auth-required/main/Section/index.tsx
@@ -1,27 +1,22 @@
 'use client';
 
-import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
-import { UserNameNotFoundError } from '@/errors';
 import { trackUserEvent, MessageEnum } from '@/utils/trackUtil';
 import { parseNumber } from '@/utils/numberUtil';
 import { COLORS, env, PATHS } from '@/constants';
 import { PostType, UserDto } from '@/types';
 import { Icon } from '@/components';
+import { getQueryClient } from '@/utils/queryUtil';
 import { Graph } from './Graph';
 
 export const Section = (p: PostType) => {
   const [open, setOpen] = useState(false);
-  const client = useQueryClient();
 
-  const { username } = client.getQueryData([PATHS.ME]) as UserDto;
-  const URL = env.VELOG_URL;
+  const username = (
+    getQueryClient().getQueryData([PATHS.ME]) as Partial<UserDto>
+  )?.username;
 
-  if (!username) {
-    throw new UserNameNotFoundError();
-  }
-
-  const url = `${URL}/@${username}/${p.slug}`;
+  const url = `${env.VELOG_URL}/@${username}/${p.slug}`;
 
   return (
     <section className="flex flex-col w-full h-fit relative">

--- a/src/utils/queryUtil.ts
+++ b/src/utils/queryUtil.ts
@@ -3,7 +3,7 @@ import { toast } from 'react-toastify';
 
 let localQueryClient: QueryClient | undefined;
 const STALE_TIME = 1000 * 60 * 3;
-const GC_TIME = 1000;
+const GC_TIME = 1000 * 60 * 20;
 
 const createQueryClient = () =>
   new QueryClient({

--- a/src/utils/revalidateUtil.ts
+++ b/src/utils/revalidateUtil.ts
@@ -1,0 +1,9 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+
+export async function revalidate() {
+  revalidatePath('/', 'layout');
+  redirect('/');
+}


### PR DESCRIPTION
원래 발생하던 유저 캐시 충돌 문제를 해결하였습니다.

~~다만 해결과 동시에 쿼리캐시 초기화 로직을 로그인 페이지로 이동시켰는데, NextJS 서버 액션의 redirect 함수가 사실상의 return 역할을 하면서 promise나 콜백 함수를 붙일 수가 없더군요.~~
~~그래서 해당 문제의 해결을 위해서 그냥 로그아웃 후 로그인 페이지로 이동했을 시의 캐시 처리는 로그인 페이지에 맡기기로 했습니다..~~

~~더 좋은 방법이 있는 경우 추천해주시면 바로 반영해보겠습니다!~~

원래는 로그인 페이지에서 캐시 초기화를 처리하는 방식으로 구현했으나, 근본적인 문제점인 me 쿼리의 refetching을 해결해서 로그인 페이지에 있던 캐시 초기화 로직은 정리하였습니다!