### PR TITLE
[25.05.14 / TASK-190] Refactor - UTC -> KST 변환 반영

### DIFF
--- a/src/app/(auth-required)/main/Content.tsx
+++ b/src/app/(auth-required)/main/Content.tsx
@@ -52,8 +52,7 @@ export const Content = () => {
         <div className="flex h-fit flex-col items-center p-[20px] bg-BG-SUB gap-5 rounded-[4px]">
           <span className="text-TEXT-ALT text-ST5 MBI:hidden">
             마지막 업데이트 :{' '}
-            {convertDateToKST(summaries?.stats?.lastUpdatedDate)?.full.toISOString() ||
-              '업데이트 중..'}
+            {convertDateToKST(summaries?.stats?.lastUpdatedDate)?.iso || '업데이트 중..'}
           </span>
           <div className="w-full flex items-center justify-between flex-wrap max-MBI:justify-center max-MBI:gap-4">
             <div className="flex items-center gap-3">
@@ -62,8 +61,7 @@ export const Content = () => {
               </Button>
               <span className="text-TEXT-ALT text-ST4 max-TBL:text-ST5 max-MBI:hidden">
                 마지막 업데이트 :{' '}
-                {convertDateToKST(summaries?.stats?.lastUpdatedDate)?.full.toISOString() ||
-                  '업데이트 중..'}
+                {convertDateToKST(summaries?.stats?.lastUpdatedDate)?.iso || '업데이트 중..'}
               </span>
             </div>
             <div className="flex items-center gap-3">

--- a/src/app/(auth-required)/main/Content.tsx
+++ b/src/app/(auth-required)/main/Content.tsx
@@ -8,6 +8,7 @@ import { Button, Dropdown, Check } from '@/components';
 import { postList, postSummary } from '@/apis';
 import { PATHS, SORT_TYPE } from '@/constants';
 import { SortKey, SortValue } from '@/types';
+import { convertDate } from '@/utils';
 import { Section, Summary } from './components';
 
 const sorts: Array<[SortKey, SortValue]> = Object.entries(SORT_TYPE) as Array<[SortKey, SortValue]>;
@@ -50,7 +51,8 @@ export const Content = () => {
       <div className="w-full flex flex-col gap-[30px] overflow-auto max-TBL:gap-[20px]">
         <div className="flex h-fit flex-col items-center p-[20px] bg-BG-SUB gap-5 rounded-[4px]">
           <span className="text-TEXT-ALT text-ST5 MBI:hidden">
-            마지막 업데이트 : {summaries?.stats?.lastUpdatedDate || 'NULL'}
+            마지막 업데이트 :{' '}
+            {convertDate(summaries?.stats?.lastUpdatedDate)?.full.toISOString() || '업데이트 중..'}
           </span>
           <div className="w-full flex items-center justify-between flex-wrap max-MBI:justify-center max-MBI:gap-4">
             <div className="flex items-center gap-3">
@@ -58,7 +60,9 @@ export const Content = () => {
                 새로고침
               </Button>
               <span className="text-TEXT-ALT text-ST4 max-TBL:text-ST5 max-MBI:hidden">
-                마지막 업데이트 : {summaries?.stats?.lastUpdatedDate || '업데이트 중..'}
+                마지막 업데이트 :{' '}
+                {convertDate(summaries?.stats?.lastUpdatedDate)?.full.toISOString() ||
+                  '업데이트 중..'}
               </span>
             </div>
             <div className="flex items-center gap-3">

--- a/src/app/(auth-required)/main/Content.tsx
+++ b/src/app/(auth-required)/main/Content.tsx
@@ -8,7 +8,7 @@ import { Button, Dropdown, Check } from '@/components';
 import { postList, postSummary } from '@/apis';
 import { PATHS, SORT_TYPE } from '@/constants';
 import { SortKey, SortValue } from '@/types';
-import { convertDate } from '@/utils';
+import { convertDateToKST } from '@/utils';
 import { Section, Summary } from './components';
 
 const sorts: Array<[SortKey, SortValue]> = Object.entries(SORT_TYPE) as Array<[SortKey, SortValue]>;
@@ -52,7 +52,8 @@ export const Content = () => {
         <div className="flex h-fit flex-col items-center p-[20px] bg-BG-SUB gap-5 rounded-[4px]">
           <span className="text-TEXT-ALT text-ST5 MBI:hidden">
             마지막 업데이트 :{' '}
-            {convertDate(summaries?.stats?.lastUpdatedDate)?.full.toISOString() || '업데이트 중..'}
+            {convertDateToKST(summaries?.stats?.lastUpdatedDate)?.full.toISOString() ||
+              '업데이트 중..'}
           </span>
           <div className="w-full flex items-center justify-between flex-wrap max-MBI:justify-center max-MBI:gap-4">
             <div className="flex items-center gap-3">
@@ -61,7 +62,7 @@ export const Content = () => {
               </Button>
               <span className="text-TEXT-ALT text-ST4 max-TBL:text-ST5 max-MBI:hidden">
                 마지막 업데이트 :{' '}
-                {convertDate(summaries?.stats?.lastUpdatedDate)?.full.toISOString() ||
+                {convertDateToKST(summaries?.stats?.lastUpdatedDate)?.full.toISOString() ||
                   '업데이트 중..'}
               </span>
             </div>

--- a/src/app/(auth-required)/main/components/Section/Graph.tsx
+++ b/src/app/(auth-required)/main/components/Section/Graph.tsx
@@ -18,6 +18,7 @@ import { Dropdown, Input } from '@/components';
 import { PostDetailValue } from '@/types';
 import { useResponsive } from '@/hooks';
 import { postDetail } from '@/apis';
+import { convertDate } from '@/utils';
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend);
 
@@ -50,7 +51,7 @@ export const Graph = ({ id, releasedAt }: IProp) => {
     queryKey: [PATHS.DETAIL, type, id],
     queryFn: async () => await postDetail(id, type.start, type.end),
     select: ({ post }) => ({
-      labels: post.map((i) => i.date.split('T')[0]),
+      labels: post.map((i) => convertDate(i.date)?.short),
       datasets: [
         {
           label: type.type,
@@ -87,7 +88,7 @@ export const Graph = ({ id, releasedAt }: IProp) => {
               size={isMBI ? 'SMALL' : 'MEDIUM'}
               form="SMALL"
               value={type.start}
-              min={releasedAt.split('T')[0]}
+              min={convertDate(releasedAt)?.short}
               onChange={(e) => setType({ ...type, start: e.target.value })}
               placeholder="시작 날짜"
               type="date"
@@ -97,7 +98,7 @@ export const Graph = ({ id, releasedAt }: IProp) => {
               size={isMBI ? 'SMALL' : 'MEDIUM'}
               form="SMALL"
               value={type.end}
-              min={type.start ? type.start : releasedAt.split('T')[0]}
+              min={type.start ? type.start : convertDate(releasedAt)?.short}
               onChange={(e) => setType({ ...type, end: e.target.value })}
               placeholder="종료 날짜"
               type="date"

--- a/src/app/(auth-required)/main/components/Section/Graph.tsx
+++ b/src/app/(auth-required)/main/components/Section/Graph.tsx
@@ -18,7 +18,7 @@ import { Dropdown, Input } from '@/components';
 import { PostDetailValue } from '@/types';
 import { useResponsive } from '@/hooks';
 import { postDetail } from '@/apis';
-import { convertDate } from '@/utils';
+import { convertDateToKST } from '@/utils';
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend);
 
@@ -51,7 +51,7 @@ export const Graph = ({ id, releasedAt }: IProp) => {
     queryKey: [PATHS.DETAIL, type, id],
     queryFn: async () => await postDetail(id, type.start, type.end),
     select: ({ post }) => ({
-      labels: post.map((i) => convertDate(i.date)?.short),
+      labels: post.map((i) => convertDateToKST(i.date)?.short),
       datasets: [
         {
           label: type.type,
@@ -88,7 +88,7 @@ export const Graph = ({ id, releasedAt }: IProp) => {
               size={isMBI ? 'SMALL' : 'MEDIUM'}
               form="SMALL"
               value={type.start}
-              min={convertDate(releasedAt)?.short}
+              min={convertDateToKST(releasedAt)?.short}
               onChange={(e) => setType({ ...type, start: e.target.value })}
               placeholder="시작 날짜"
               type="date"
@@ -98,7 +98,7 @@ export const Graph = ({ id, releasedAt }: IProp) => {
               size={isMBI ? 'SMALL' : 'MEDIUM'}
               form="SMALL"
               value={type.end}
-              min={type.start ? type.start : convertDate(releasedAt)?.short}
+              min={type.start ? type.start : convertDateToKST(releasedAt)?.short}
               onChange={(e) => setType({ ...type, end: e.target.value })}
               placeholder="종료 날짜"
               type="date"

--- a/src/app/(auth-required)/main/components/Section/index.tsx
+++ b/src/app/(auth-required)/main/components/Section/index.tsx
@@ -6,6 +6,7 @@ import { COLORS, env, PATHS } from '@/constants';
 import { PostType, UserDto } from '@/types';
 import { Icon } from '@/components';
 import { getQueryClient } from '@/utils/queryUtil';
+import { convertDate } from '@/utils';
 import { Graph } from './Graph';
 
 export const Section = (p: PostType) => {
@@ -39,12 +40,12 @@ export const Section = (p: PostType) => {
           </div>
 
           <span className="text-TEXT-ALT text-ST4 MBI:content-[attr(data-date)] max-MBI:hidden">
-            {p.releasedAt.split('T')[0]}
+            {convertDate(p.releasedAt)?.short}
           </span>
         </div>
 
         <div className="flex items-center text-ST4 justify-between text-TEXT-ALT gap-1 max-TBL:text-ST5 max-MBI:w-full">
-          <span className="MBI:hidden">{p.releasedAt.split('T')[0]}</span>
+          <span className="MBI:hidden">{convertDate(p.releasedAt)?.short}</span>
           <div className="flex flex-wrap items-center gap-[6px]">
             <span className='after:content-["/"] after:ml-2'>{parseNumber(p.views)}</span>
             <span className="flex items-center before:text-PRIMARY-SUB before:content-['↑'] before:mr-1 after:ml-2 after:content-['/']">

--- a/src/app/(auth-required)/main/components/Section/index.tsx
+++ b/src/app/(auth-required)/main/components/Section/index.tsx
@@ -6,7 +6,7 @@ import { COLORS, env, PATHS } from '@/constants';
 import { PostType, UserDto } from '@/types';
 import { Icon } from '@/components';
 import { getQueryClient } from '@/utils/queryUtil';
-import { convertDate } from '@/utils';
+import { convertDateToKST } from '@/utils';
 import { Graph } from './Graph';
 
 export const Section = (p: PostType) => {
@@ -40,12 +40,12 @@ export const Section = (p: PostType) => {
           </div>
 
           <span className="text-TEXT-ALT text-ST4 MBI:content-[attr(data-date)] max-MBI:hidden">
-            {convertDate(p.releasedAt)?.short}
+            {convertDateToKST(p.releasedAt)?.short}
           </span>
         </div>
 
         <div className="flex items-center text-ST4 justify-between text-TEXT-ALT gap-1 max-TBL:text-ST5 max-MBI:w-full">
-          <span className="MBI:hidden">{convertDate(p.releasedAt)?.short}</span>
+          <span className="MBI:hidden">{convertDateToKST(p.releasedAt)?.short}</span>
           <div className="flex flex-wrap items-center gap-[6px]">
             <span className='after:content-["/"] after:ml-2'>{parseNumber(p.views)}</span>
             <span className="flex items-center before:text-PRIMARY-SUB before:content-['↑'] before:mr-1 after:ml-2 after:content-['/']">

--- a/src/utils/dateUtil.ts
+++ b/src/utils/dateUtil.ts
@@ -12,7 +12,7 @@ export const convertDateToKST = (date?: string) => {
   const seconds = converted.getSeconds().toString().padStart(2, '0');
 
   return {
-    short: `${converted.getFullYear()}-${converted.getMonth() + 1}-${converted.getDate()}`,
+    short: `${converted.getFullYear()}-${(converted.getMonth() + 1).toString().padStart(2, '0')}-${converted.getDate().toString().padStart(2, '0')}`,
     iso: `${year}-${month}-${day}T${hours}:${minutes}:${seconds}+09:00`,
     full: converted,
   };

--- a/src/utils/dateUtil.ts
+++ b/src/utils/dateUtil.ts
@@ -1,11 +1,19 @@
 const KST_DIFF = 9 * 60 * 60 * 1000;
 
 export const convertDateToKST = (date?: string) => {
-  if (date) {
-    const converted = new Date(new Date(date).getTime() + KST_DIFF);
-    return {
-      short: `${converted.getFullYear()}-${converted.getMonth() + 1}-${converted.getDate()}`,
-      full: converted,
-    };
-  }
+  if (!date) return;
+  const converted = new Date(new Date(date).getTime() + KST_DIFF);
+
+  const year = converted.getFullYear();
+  const month = (converted.getMonth() + 1).toString().padStart(2, '0');
+  const day = converted.getDate().toString().padStart(2, '0');
+  const hours = converted.getHours().toString().padStart(2, '0');
+  const minutes = converted.getMinutes().toString().padStart(2, '0');
+  const seconds = converted.getSeconds().toString().padStart(2, '0');
+
+  return {
+    short: `${converted.getFullYear()}-${converted.getMonth() + 1}-${converted.getDate()}`,
+    iso: `${year}-${month}-${day}T${hours}:${minutes}:${seconds}+09:00`,
+    full: converted,
+  };
 };

--- a/src/utils/dateUtil.ts
+++ b/src/utils/dateUtil.ts
@@ -1,6 +1,5 @@
 const KST_DIFF = 9 * 60 * 60 * 1000;
 
-/**  */
 export const convertDateToKST = (date?: string) => {
   if (date) {
     const converted = new Date(new Date(date).getTime() + KST_DIFF);

--- a/src/utils/dateUtil.ts
+++ b/src/utils/dateUtil.ts
@@ -1,5 +1,24 @@
 const KST_DIFF = 9 * 60 * 60 * 1000;
 
+/**
+ * 주어진 날짜 문자열을 KST(한국 표준시) 기준으로 변환함.
+ *
+ * @param {string} [date] - 변환할 날짜 문자열 (예: "2025-05-15T08:00:00Z")
+ * @returns {{
+ *   short: string; // "YYYY-MM-DD" 형식의 날짜 문자열
+ *   iso: string;   // ISO 8601 형식 + KST 오프셋 포함 문자열
+ *   full: Date;    // KST로 보정된 Date 객체
+ * } | undefined} 날짜가 없으면 undefined 반환
+ *
+ * @example
+ * convertDateToKST("2025-05-15T08:00:00Z");
+ * // {
+ * //   short: "2025-05-15",
+ * //   iso: "2025-05-15T17:00:00+09:00",
+ * //   full: Date(2025-05-15T17:00:00.000+09:00)
+ * // }
+ */
+
 export const convertDateToKST = (date?: string) => {
   if (!date) return;
   const converted = new Date(new Date(date).getTime() + KST_DIFF);
@@ -12,7 +31,7 @@ export const convertDateToKST = (date?: string) => {
   const seconds = converted.getSeconds().toString().padStart(2, '0');
 
   return {
-    short: `${converted.getFullYear()}-${(converted.getMonth() + 1).toString().padStart(2, '0')}-${converted.getDate().toString().padStart(2, '0')}`,
+    short: `${converted.getFullYear()}-${(converted.getMonth() + 1).toString().padStart(2, '0')}-${converted.getDate()}`,
     iso: `${year}-${month}-${day}T${hours}:${minutes}:${seconds}+09:00`,
     full: converted,
   };

--- a/src/utils/dateUtil.ts
+++ b/src/utils/dateUtil.ts
@@ -9,14 +9,6 @@ const KST_DIFF = 9 * 60 * 60 * 1000;
  *   iso: string;   // ISO 8601 형식 + KST 오프셋 포함 문자열
  *   full: Date;    // KST로 보정된 Date 객체
  * } | undefined} 날짜가 없으면 undefined 반환
- *
- * @example
- * convertDateToKST("2025-05-15T08:00:00Z");
- * // {
- * //   short: "2025-05-15",
- * //   iso: "2025-05-15T17:00:00+09:00",
- * //   full: Date(2025-05-15T17:00:00.000+09:00)
- * // }
  */
 
 export const convertDateToKST = (date?: string) => {

--- a/src/utils/dateUtil.tsx
+++ b/src/utils/dateUtil.tsx
@@ -1,0 +1,11 @@
+const KST_DIFF = 9 * 60 * 60 * 1000;
+
+export const convertDate = (date?: string) => {
+  if (date) {
+    const converted = new Date(new Date(date).getTime() + KST_DIFF);
+    return {
+      short: `${converted.getFullYear()}-${converted.getMonth() + 1}-${converted.getDate()}`,
+      full: converted,
+    };
+  }
+};

--- a/src/utils/dateUtil.tsx
+++ b/src/utils/dateUtil.tsx
@@ -1,6 +1,7 @@
 const KST_DIFF = 9 * 60 * 60 * 1000;
 
-export const convertDate = (date?: string) => {
+/**  */
+export const convertDateToKST = (date?: string) => {
   if (date) {
     const converted = new Date(new Date(date).getTime() + KST_DIFF);
     return {

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -1,2 +1,3 @@
 export * from './componentUtil';
 export * from './numberUtil';
+export * from './dateUtil';


### PR DESCRIPTION
## 🔥 변경 사항
UTC로 변환된 서버에 맞추기 위해, 클라이언트에서 KST 변환을 적용하였습니다.
원래는 3시쯤 PR을 열었어야 했으나, 다른 작업으로 인해 조금 많이 늦어졌습니다.. 죄송합니다! (리더보드 PR에서 간략히 설명드릴 예정입니다!)

## 🏷 관련 이슈
- 관련 이슈: `#190`

## 📸 스크린샷 (UI 변경 시 필수)
X

## 📌 체크리스트
- [X] 기능이 정상적으로 동작하는지 테스트 완료
- [X] 코드 스타일 가이드 준수 여부 확인
- [X] 관련 문서 업데이트 완료 (필요 시)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 날짜를 한국 표준시(KST) 기준으로 변환해 표시하는 기능이 추가되었습니다.

- **버그 수정**
    - 날짜 표시가 일관적으로 포맷되어 잘못된 날짜 형식이나 NULL 값 대신 "업데이트 중.."으로 안내됩니다.

- **리팩터링**
    - 날짜 처리 로직이 유틸리티 함수로 통합되어 코드의 일관성과 유지보수성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->