### PR TITLE
[TASK-211 / 25.07.01] Feature - 리더보드 username 대응 개발

### DIFF
--- a/src/app/(auth-required)/leaderboards/Content.tsx
+++ b/src/app/(auth-required)/leaderboards/Content.tsx
@@ -5,7 +5,7 @@ import { startHolyLoader } from 'holy-loader';
 import { useMemo } from 'react';
 import { leaderboardList } from '@/apis';
 import { Rank } from '@/app/components';
-import { PATHS } from '@/constants';
+import { PATHS, URLS } from '@/constants';
 import { useSearchParam } from '@/hooks';
 import { Dropdown } from '@/shared';
 import { LeaderboardItemType } from '@/types';
@@ -30,9 +30,11 @@ export const Content = () => {
       searchParams.based === 'user' ? boards?.users : boards?.posts
     ) as LeaderboardItemType[];
     return (
-      value.map((item) => ({
-        name: searchParams.based === 'user' ? item.email.split('@')[0] : item.title,
-        value: searchParams.sort === 'viewCount' ? item.viewDiff : item.likeDiff,
+      value.map(({ username, title, viewDiff, likeDiff, slug }) => ({
+        key: searchParams.based === 'user' ? username : title,
+        username,
+        url: `${URLS.VELOG}/@${username}/${searchParams.based === 'user' ? 'posts' : `${slug}`}`,
+        value: searchParams.sort === 'viewCount' ? viewDiff : likeDiff,
       })) || []
     );
   }, [boards, searchParams.based, searchParams.sort]);
@@ -86,8 +88,15 @@ export const Content = () => {
       </div>
 
       <div className="w-full flex flex-wrap gap-5 overflow-auto">
-        {data?.map(({ name, value }, index) => (
-          <Rank name={name} key={index} count={value} rank={index + 1} />
+        {data?.map(({ key, username, url, value }, index) => (
+          <Rank
+            name={key}
+            key={index}
+            url={url}
+            count={value}
+            rank={index + 1}
+            suffix={searchParams.based === 'post' ? username : ''}
+          />
         ))}
       </div>
     </div>

--- a/src/app/components/Rank.tsx
+++ b/src/app/components/Rank.tsx
@@ -1,32 +1,46 @@
+'use client';
+
 import { HTMLAttributes } from 'react';
 import { twMerge } from 'tailwind-merge';
 
 export interface IProp extends HTMLAttributes<HTMLDivElement> {
   name: string;
   rank: number;
+  url: string;
   count?: string | number;
   suffix?: string;
 }
 
 const colorTable = ['border-[#DAA520]', 'border-[#A9A9A9]', 'border-[#B87333]'];
 
-export const Rank = ({ name, rank, count, suffix = '회' }: IProp) => {
+export const Rank = ({ name, rank, count, url, suffix }: IProp) => {
   return (
     <div
       className={twMerge(
-        'min-w-[40%] w-full p-[25px] bg-BG-SUB rounded-[4px] gap-3 justify-between flex',
+        'min-w-[40%] group w-full p-[25px] bg-BG-SUB rounded-[4px] gap-3 justify-between flex cursor-pointer items-center',
         rank > 3 ? 'border-0' : `border-2 ${colorTable[rank - 1]}`,
       )}
+      onClick={() => window.open(url)}
     >
-      <span
-        data-rank={rank}
-        className="text-TITLE-3 text-TEXT-MAIN flex items-center gap-3 before:content-[attr(data-rank)_'위'] before:text-SUBTITLE-4 before:text-TEXT-ALT max-TBL:text-TITLE-4 max-TBL:before:text-SUBTITLE-5 max-MBI:text-SUBTITLE-4 max-MBI:before:text-SUBTITLE-5"
-      >
-        {name}
-      </span>
+      <div className="flex items-center gap-3">
+        <span className="text-SUBTITLE-4 text-TEXT-ALT shrink-0 max-TBL:text-SUBTITLE-5 max-MBI:text-SUBTITLE-5">
+          {rank + '위'}
+        </span>
+
+        <div className=" flex flex-col gap-0">
+          <span className="group-hover:underline text-TITLE-3 text-TEXT-MAIN flex items-center gap-3 max-TBL:text-TITLE-4 max-MBI:text-SUBTITLE-4">
+            {name}
+          </span>
+          {suffix !== undefined && (
+            <span className="text-SUBTITLE-4 text-TEXT-ALT max-TBL:text-SUBTITLE-5 max-MBI:text-SUBTITLE-5">
+              {String(suffix)}
+            </span>
+          )}
+        </div>
+      </div>
+
       <span className="text-SUBTITLE-3 shrink-0 text-TEXT-SUB max-TBL:text-TITLE-4 max-MBI:text-SUBTITLE-4">
-        {count}
-        {suffix}
+        {count}회
       </span>
     </div>
   );

--- a/src/types/leaderboard.type.ts
+++ b/src/types/leaderboard.type.ts
@@ -1,6 +1,7 @@
 type LeaderboardListUser = {
   id: string;
   email: string;
+  username: string;
   totalViews: string;
   totalLikes: string;
   totalPosts: string;
@@ -12,6 +13,7 @@ type LeaderboardListPost = {
   id: string;
   title: string;
   slug: string;
+  username: string;
   totalViews: number;
   totalLikes: number;
   viewDiff: number;


### PR DESCRIPTION
## 🔥 변경 사항
은다님께서 대응해주신 리더보드 username 대응 개발을 프론트엔드에서도 진행하였습니다!

랭크 표시 부분을 수정하면서 "게시글 기준" 에서의 username을 어떻게 표시
해야 할지 고민이 됬는데, 우선은 이미지와 같은 방식으로 구현해봤습니다.
혹시 더 괜찮은 아이디어가 있으시다면, 제안해주시면 정말 감사드리겠습니다!

## 🏷 관련 이슈
- 관련 이슈: X

## 📸 스크린샷 (UI 변경 시 필수)
<img width="1691" alt="스크린샷 2025-07-01 오후 1 27 59" src="https://github.com/user-attachments/assets/954cc26d-3850-422e-97a5-4808579aa12e" />
<img width="1693" alt="스크린샷 2025-07-01 오후 1 28 07" src="https://github.com/user-attachments/assets/615529c9-f385-4361-b7d0-b337e0c73ff4" />

## 📌 체크리스트
- [X] 기능이 정상적으로 동작하는지 테스트 완료
- [X] 코드 스타일 가이드 준수 여부 확인
- [X] 관련 문서 업데이트 완료 (필요 시)
